### PR TITLE
fixpkg: use SPDX license identifier & update BuildRequires

### DIFF
--- a/dae.spec
+++ b/dae.spec
@@ -4,13 +4,12 @@ Name:           dae
 Version:        0.8.0
 Release:        1%{?dist}
 Summary:        A Linux lightweight and high-performance transparent proxy solution based on eBPF.
-License:        AGPL
+License:        AGPL-3.0-or-later
 URL:            https://github.com/daeuniverse/dae
 Source0:        %{url}/releases/download/v%{version}/dae-full-src.zip
 BuildRequires:  clang-devel
 BuildRequires:  llvm-devel
-BuildRequires:  git
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       glibc
 Requires:       v2ray-geoip
 Requires:       v2ray-domain-list-community


### PR DESCRIPTION
- According to [Licensing Guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/#_license_field):
> The License: field for new packages as of July 2022 must be filled with the appropriate SPDX license identifier or expression from the list of [allowed licenses](https://docs.fedoraproject.org/en-US/legal/allowed-licenses/) for Fedora. 